### PR TITLE
Add E2E coverage for Python agent

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,8 +22,17 @@ on:
     branches:
       - master
   pull_request:
-#  schedule: TODO: unpin minor lib versions and check weekly
-#    - 0 0 0 ? * FRI *
+    paths-ignore:
+      - "*.md"
+      - "*.txt"
+      - ".asf.yaml"
+      - ".dlc.json"
+      - ".licenserc.yaml"
+      - "docs/*"
+      - ".github/workflows/*"
+  schedule: #TODO: unpin minor lib versions and check weekly with automation
+    - cron: '0 18 * * *'
+
 concurrency:
   group: ci-it-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -62,7 +71,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
         test-path: ${{fromJson(needs.prep-plugin-and-unit-tests.outputs.matrix)}}
       fail-fast: false
     env:
@@ -85,7 +94,7 @@ jobs:
   CheckStatus:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [plugin-and-unit-tests]
+    needs: [ plugin-and-unit-tests ]
     steps:
       - name: Nothing
         run: echo "Just to make the GitHub merge button green"

--- a/.github/workflows/dead-link-checker.yaml
+++ b/.github/workflows/dead-link-checker.yaml
@@ -18,6 +18,11 @@ name: Dead Link Checker
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 18 * * *'
 
 concurrency:
   group: dlc-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: E2E
+
+on:
+  pull_request:
+    paths-ignore:
+      - "*.md"
+      - "*.txt"
+      - ".asf.yaml"
+      - ".dlc.json"
+      - ".licenserc.yaml"
+      - "docs/*"
+      - ".github/workflows/*"
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 18 * * *'
+
+concurrency:
+  group: ci-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  E2E:
+    name: Basic function + ${{ matrix.case.name }} transport (Python3.7)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        case:
+          - name: gRPC
+            path: tests/e2e/case/grpc/e2e.yaml
+          - name: HTTP
+            path: tests/e2e/case/http/e2e.yaml
+          - name: Kafka
+            path: tests/e2e/case/kafka/e2e.yaml
+      fail-fast: false
+    steps:
+      - name: Checkout source codes
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+#      - name: Set up Python 3.7
+#        uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.7
+#      - name: Set up dependencies
+#        run: make setup install
+      - name: Build SkyWalking Python agent base image
+        run: docker build --build-arg SW_PYTHON_VERSION -t skywalking/skywalking-python-agent:3.7-latest .
+        env:
+          SW_PYTHON_VERSION: 3.7
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+      - name: Run E2E Tests
+        uses: apache/skywalking-infra-e2e@main
+        with:
+          log-dir: /tmp/e2e-logs
+          e2e-file: ${{ matrix.case.path }}
+      - name: Upload Logs
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: e2e_logs
+          path: "${{ env.SW_INFRA_E2E_LOG_DIR }}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,4 +23,5 @@ ARG SW_PYTHON_AGENT_VERSION
 
 RUN pip install --no-cache-dir "apache-skywalking[${SW_PYTHON_AGENT_PROTOCOL}]==${SW_PYTHON_AGENT_VERSION}"
 
+# So that the agent can be auto-started when container is started
 ENTRYPOINT ["sw-python", "run"]

--- a/skywalking/__init__.py
+++ b/skywalking/__init__.py
@@ -45,7 +45,7 @@ class Component(Enum):
     Celery = 7011
     Falcon = 7012
     MysqlClient = 7013
-    FastApi = 7014
+    FastAPI = 7014
 
 
 class Layer(Enum):

--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -21,8 +21,6 @@ from queue import Queue, Full
 from threading import Thread, Event
 from typing import TYPE_CHECKING
 
-from skywalking.protocol.logging.Logging_pb2 import LogData
-
 from skywalking import config, plugins
 from skywalking import loggings
 from skywalking import profile
@@ -31,6 +29,7 @@ from skywalking.command import command_service
 from skywalking.loggings import logger
 from skywalking.profile.profile_task import ProfileTask
 from skywalking.profile.snapshot import TracingThreadSnapshot
+from skywalking.protocol.logging.Logging_pb2 import LogData
 
 if TYPE_CHECKING:
     from skywalking.trace.context import Segment

--- a/skywalking/client/grpc.py
+++ b/skywalking/client/grpc.py
@@ -38,6 +38,7 @@ class GrpcServiceManagementClient(ServiceManagementClient):
         self.service_stub = ManagementServiceStub(channel)
 
     def send_instance_props(self):
+        # TODO: other properties periodically | matching behavior of java agent
         self.service_stub.reportInstanceProperties(InstanceProperties(
             service=config.service_name,
             serviceInstance=config.service_instance,

--- a/skywalking/plugins/sw_fastapi.py
+++ b/skywalking/plugins/sw_fastapi.py
@@ -55,7 +55,7 @@ def install():
 
         with span:
             span.layer = Layer.Http
-            span.component = Component.FastApi
+            span.component = Component.FastAPI
             span.peer = f'{req.client.host}:{req.client.port}'
             span.tag(TagHttpMethod(method))
             span.tag(TagHttpURL(req.url._url.split('?')[0]))

--- a/tests/e2e/base/__init__.py
+++ b/tests/e2e/base/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e/base/consumer/Dockerfile
+++ b/tests/e2e/base/consumer/Dockerfile
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: Base image is a general purpose image containing multiple protocols
+# without non-intrusive entrypoint.
+FROM skywalking/skywalking-python-agent:3.7-latest
+
+VOLUME /services
+COPY consumer.py /services/
+RUN pip install fastapi uvicorn aiohttp
+RUN pip install kafka-python
+
+# Execute the consumer.py with agent attached
+CMD ["sw-python", "run", "python3", "/services/consumer.py"]

--- a/tests/e2e/base/consumer/__init__.py
+++ b/tests/e2e/base/consumer/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e/base/consumer/consumer.py
+++ b/tests/e2e/base/consumer/consumer.py
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+This module contains the Consumer part of the e2e tests.
+consumer (FastAPI) -> consumer (AIOHTTP) -> provider (FastAPI + logging_with_exception)
+"""
+import aiohttp
+import uvicorn
+from fastapi import FastAPI
+from fastapi import Request
+
+app = FastAPI()
+
+
+@app.get('/artist')
+@app.post('/artist')
+async def application(request: Request):
+    try:
+        payload = await request.json()
+        async with aiohttp.ClientSession() as session:
+            async with session.post('http://provider:9090/artist', data=payload) as response:
+                return await response.json()
+    except Exception:  # noqa
+        return {'message': 'Error'}
+
+
+if __name__ == '__main__':
+    # noinspection PyTypeChecker
+    uvicorn.run(app, host='0.0.0.0', port=9090)

--- a/tests/e2e/base/docker-compose.base.yml
+++ b/tests/e2e/base/docker-compose.base.yml
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '2.1'
+
+services:
+  # The following services are inherited by three protocols for testing
+  oap: # TODO: bump up OAP version from time to time | 2022-03-25
+    image: ghcr.io/apache/skywalking/oap:547f1ede2d1665601cb9d9a3853ed205620d6c83
+    # Python agent supports gRPC/ HTTP/ Kafka reporting
+    expose:
+      - 11800 # gRPC
+      - 12800 # HTTP
+    networks:
+      - e2e
+    restart: on-failure
+    healthcheck: # python base image has no nc command
+      test: [ "CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/11800" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+  provider:
+    build:
+      context: provider
+    image: skywalking-agent:e2e-provider
+    expose:
+      - 9090
+    networks:
+      - e2e
+    environment:
+      SW_AGENT_NAME: e2e-service-provider
+      SW_AGENT_INSTANCE: provider1
+      SW_AGENT_LOGGING_LEVEL: DEBUG
+      SW_AGENT_LOG_REPORTER_ACTIVE: "True"
+      SW_AGENT_LOG_REPORTER_LEVEL: WARNING
+    healthcheck:
+      test: [ "CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9090" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+  consumer:
+    build:
+      context: consumer
+    image: skywalking-agent:e2e-consumer
+    expose:
+      - 9090
+    networks:
+      - e2e
+    environment:
+      SW_AGENT_NAME: e2e-service-consumer
+      SW_AGENT_INSTANCE: consumer1
+      SW_AGENT_LOGGING_LEVEL: DEBUG
+      SW_AGENT_LOG_REPORTER_ACTIVE: "True"
+      SW_AGENT_LOG_REPORTER_LEVEL: WARNING
+    healthcheck:
+      test: [ "CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9090" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+networks:
+  e2e:

--- a/tests/e2e/base/provider/Dockerfile
+++ b/tests/e2e/base/provider/Dockerfile
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM skywalking/skywalking-python-agent:3.7-latest
+
+VOLUME /services
+COPY provider.py /services/
+RUN pip install fastapi uvicorn
+RUN pip install kafka-python
+
+# Execute the provider.py with agent attached
+CMD ["sw-python", "run", "python3", "/services/provider.py"]

--- a/tests/e2e/base/provider/__init__.py
+++ b/tests/e2e/base/provider/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e/base/provider/provider.py
+++ b/tests/e2e/base/provider/provider.py
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+This module contains the Provider part of the e2e tests.
+consumer (FastAPI) -> consumer (AIOHTTP) -> provider (FastAPI + logging_with_exception)
+We also cover the usage of logging interception in this module.
+"""
+import io
+import logging
+import random
+import time
+import traceback
+
+import uvicorn
+from fastapi import FastAPI
+
+
+class E2EProviderFormatter(logging.Formatter):
+    """
+    User defined formatter should in no way be
+    interfered by the log reporter formatter.
+    """
+
+    def format(self, record):
+        result = super().format(record)
+        return 'e2e_provider:=' + result
+
+    def formatException(self, ei):  # noqa
+        """
+        Mock user defined formatter which limits the traceback depth
+        to None -> meaning it will not involve trackback at all.
+        but the agent should still be able to capture the traceback
+        at default level of 5 by ignoring the cache.
+        """
+        sio = io.StringIO()
+        tb = ei[2]
+        traceback.print_exception(ei[0], ei[1], tb, None, sio)
+        s = sio.getvalue()
+        sio.close()
+        if s[-1:] == '\n':
+            s = s[:-1]
+        return s
+
+
+formatter = E2EProviderFormatter(logging.BASIC_FORMAT)
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(formatter)
+
+e2e_provider_logger = logging.getLogger('__name__')
+e2e_provider_logger.setLevel(logging.INFO)
+e2e_provider_logger.addHandler(stream_handler)
+
+app = FastAPI()
+
+
+@app.get('/artist')
+@app.post('/artist')
+async def application():
+    time.sleep(random.random())
+    # Warning is reported
+    e2e_provider_logger.warning('E2E Provider Warning, this is reported!')
+    # Debug is not reported according to default agent setting
+    e2e_provider_logger.debug('E2E Provider Debug, this is not reported!')
+
+    # Exception is reported with trackback depth of 5 (default)
+    try:
+        raise Exception('E2E Provider Exception Text!')
+    except Exception:  # noqa
+        e2e_provider_logger.exception('E2E Provider Exception, this is reported!')
+
+    return {'artist': 'Luis Fonsi'}
+
+
+if __name__ == '__main__':
+    # noinspection PyTypeChecker
+    uvicorn.run(app, host='0.0.0.0', port=9090)

--- a/tests/e2e/case/expected/logs-list.yml
+++ b/tests/e2e/case/expected/logs-list.yml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+logs:
+  {{- contains .logs }}
+  - servicename: e2e-service-provider
+    serviceid: {{ b64enc "e2e-service-provider" }}.1
+    serviceinstancename: provider1
+    serviceinstanceid: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}
+    endpointname: null
+    endpointid: null
+    traceid: {{ notEmpty .traceid }}
+    timestamp: {{ gt .timestamp 0 }}
+    contenttype: TEXT
+    content: {{ regexp .content "(?s).+E2E Provider Warning.+"}}
+    tags:
+    {{- contains .tags }}
+    - key: level
+      value: WARNING
+    - key: logger
+      value: {{ notEmpty .value }}
+    - key: thread
+      value: {{ notEmpty .value }}
+    {{- end }}
+  - servicename: e2e-service-provider
+    serviceid: { { b64enc "e2e-service-provider" } }.1
+    serviceinstancename: provider1
+    serviceinstanceid: { { b64enc "e2e-service-provider" } }.1_{{ b64enc "provider1" }}
+    endpointname: null
+    endpointid: null
+    traceid: { { notEmpty .traceid } }
+    timestamp: { { gt .timestamp 0 } }
+    contenttype: TEXT
+    content: { { regexp .content "(?s).+E2E Provider Exception.+Traceback(most recent call last).+" } }
+    tags:
+    { { - contains .tags } }
+    - key: level
+      value: ERROR
+    - key: logger
+      value: { { notEmpty .value } }
+    - key: thread
+      value: { { notEmpty .value } }
+    { { - end } }
+  {{- end }}
+total: 2

--- a/tests/e2e/case/expected/metrics-has-value.yml
+++ b/tests/e2e/case/expected/metrics-has-value.yml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- contains . }}
+- key: {{ notEmpty .key }}
+  value: {{ ge .value 0 }}
+- key: {{ notEmpty .key }}
+  value: {{ ge .value 1 }}
+{{- end }}

--- a/tests/e2e/case/expected/service-endpoint.yml
+++ b/tests/e2e/case/expected/service-endpoint.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  {{- contains . }}
+- id: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "/artist" }}
+  name: /artist
+  {{- end }}

--- a/tests/e2e/case/expected/service-instance.yml
+++ b/tests/e2e/case/expected/service-instance.yml
@@ -1,0 +1,36 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- contains . }}
+- id: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}
+  name: {{ notEmpty .name }}
+  attributes:
+    {{- contains .attributes }}
+# TODO: The following attributes implementation is missing
+#    - name: OS Name
+#      value: linux
+#    - name: hostname
+#      value: {{ notEmpty .value }}
+#    - name: Process No.
+#      value: {{ notEmpty .value }}
+    - name: ipv4s
+      value: ""
+    {{- end}}
+  language: PYTHON
+  instanceuuid: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}
+  layer: GENERAL
+{{- end}}

--- a/tests/e2e/case/expected/service.yml
+++ b/tests/e2e/case/expected/service.yml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- id: {{ b64enc "e2e-service-provider" }}.1
+  name: e2e-service-provider
+  shortname: e2e-service-provider
+  normal: true
+  layers:
+    - GENERAL
+  group: ""
+- id: {{ b64enc "e2e-service-consumer" }}.1
+  name: e2e-service-consumer
+  shortname: e2e-service-consumer
+  normal: true
+  layers:
+    - GENERAL
+  group: ""

--- a/tests/e2e/case/expected/trace-artist-detail.yml
+++ b/tests/e2e/case/expected/trace-artist-detail.yml
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spans:
+{{- contains .spans }}
+- traceid: {{ notEmpty .traceid }}
+  segmentid: {{ notEmpty .segmentid }}
+  spanid: {{ .spanid }}
+  parentspanid: {{ .parentspanid }}
+  refs: []
+  servicecode: e2e-service-consumer
+  serviceinstancename: consumer1
+  starttime: {{ gt .starttime 0 }}
+  endtime: {{ gt .endtime 0 }}
+  endpointname: /artist
+  type: Entry
+  peer: {{ notEmpty .peer }}
+  component: FastAPI
+  iserror: false
+  layer: Http
+  tags:
+    {{- contains .tags }}
+    - key: http.method
+      value: POST
+    - key: http.url
+      value: {{ notEmpty .value }}
+    - key: http.status.code
+      value: "200"
+    {{- end }}
+  logs: []
+- traceid: {{ notEmpty .traceid }}
+  segmentid: {{ notEmpty .segmentid }}
+  spanid: {{ .spanid }}
+  parentspanid: {{ .parentspanid }}
+  refs: []
+  servicecode: e2e-service-consumer
+  serviceinstancename: consumer1
+  starttime: {{ gt .starttime 0 }}
+  endtime: {{ gt .endtime 0 }}
+  endpointname: /artist
+  type: Exit
+  peer: provider:9090
+  component: AioHttp
+  iserror: false
+  layer: Http
+  tags:
+    {{- contains .tags }}
+    - key: http.method
+      value: POST
+    - key: http.url
+      value: http://provider:9090/artist
+    - key: http.status.code
+      value: "200"
+    {{- end }}
+  logs: []
+- traceid: {{ notEmpty .traceid }}
+  segmentid: {{ notEmpty .segmentid }}
+  spanid: {{ .spanid }}
+  parentspanid: {{ .parentspanid }}
+  refs:
+    {{- contains .refs }}
+    - traceid: {{ notEmpty .traceid }}
+      parentsegmentid: {{ .parentsegmentid }}
+      parentspanid: {{ .parentspanid }}
+      type: CROSS_PROCESS
+    {{- end }}
+  servicecode: e2e-service-provider
+  serviceinstancename: provider1
+  starttime: {{ gt .starttime 0 }}
+  endtime: {{ gt .endtime 0 }}
+  endpointname: /artist
+  type: Entry
+  peer: {{ notEmpty .peer }}
+  component: FastAPI
+  iserror: false
+  layer: Http
+  tags:
+    {{- contains .tags }}
+    - key: http.method
+      value: "POST"
+    - key: http.url
+      # Change OAP side e2e from url -> http.url # why is oap e2e passing?? todo check with custom e2e build
+      value: http://provider:9090/artist
+    - key: http.status.code
+      # Change OAP side e2e from status.code -> http.status.code
+      value: "200"
+    {{- end }}
+  logs: []
+{{- end }}

--- a/tests/e2e/case/expected/traces-list.yml
+++ b/tests/e2e/case/expected/traces-list.yml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+traces:
+  {{- contains .traces }}
+  - segmentid: {{ notEmpty .segmentid }}
+    endpointnames:
+    {{- contains .endpointnames }}
+      - /artist
+    {{- end }}
+    duration: {{ ge .duration 0 }}
+    start: "{{ notEmpty .start}}"
+    iserror: false
+    traceids:
+      - {{ (index .traceids 0) }}
+  {{- end }}
+total: {{ gt .total 0 }}

--- a/tests/e2e/case/grpc/docker-compose.yml
+++ b/tests/e2e/case/grpc/docker-compose.yml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '2.1'
+
+services:
+  oap:
+    extends:
+      file: ../../base/docker-compose.base.yml
+      service: oap
+    ports:
+      - "12800"
+  provider:
+    extends:
+      file: ../../base/docker-compose.base.yml
+      service: provider
+    ports:
+      - "9090"
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
+    depends_on:
+      oap:
+        condition: service_healthy
+
+  consumer:
+    extends:
+      file: ../../base/docker-compose.base.yml
+      service: consumer
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
+    ports:
+      - "9090"
+    depends_on:
+      provider:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/tests/e2e/case/grpc/e2e.yaml
+++ b/tests/e2e/case/grpc/e2e.yaml
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: install yq
+      command: bash tests/e2e/script/prepare/install.sh yq
+    - name: install swctl
+      command: bash tests/e2e/script/prepare/install.sh swctl
+
+cleanup:
+  # change to success if debugging.
+  on: always
+
+trigger:
+  action: http      # The action of the trigger. support HTTP invoke.
+  interval: 3s      # Trigger the action every 3 seconds.
+  times: 5          # Don't omit this!
+  url: http://${consumer_host}:${consumer_9090}/artist
+  method: POST       # Http trigger method.
+  headers:
+    "Content-Type": "application/json"
+  body: '{"song": "Despacito"}'
+
+verify:
+  # verify with retry strategy
+  retry:
+    # max retry count
+    count: 20
+    # the interval between two retries
+    interval: 5s
+  cases:
+    # basic check: service list
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql service ls
+      expected: ../expected/service.yml
+    # basic check: service metrics
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name service_sla --service-name=e2e-service-provider |yq e 'to_entries' -
+      expected: ../expected/metrics-has-value.yml
+    # basic check: service endpoint
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql endpoint list --service-name=e2e-service-provider
+      expected: ../expected/service-endpoint.yml
+    # basic check: service endpoint metrics
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name endpoint_cpm --endpoint-name=/artist --service-name=e2e-service-provider |yq e 'to_entries' -
+      expected: ../expected/metrics-has-value.yml
+
+    # service instance list
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql instance list --service-name=e2e-service-provider
+      expected: ../expected/service-instance.yml
+
+    # TODO: Metric Collection Implementation is not merged https://github.com/apache/skywalking/issues/7084
+    # service instance pvm metrics TODO: PVM Collection Implementation needed https://github.com/apache/skywalking/issues/5944
+    # swctl --display yaml --base-url=http://localhost:12800/graphql metrics linear --name instance_jvm_thread_live_count --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
+    #    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name instance_jvm_thread_live_count --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
+    #      expected: ../expected/metrics-has-value.yml
+
+    # trace segment list
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls
+      expected: ../expected/traces-list.yml
+
+    # trace detail
+    - query: |
+        swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace $( \
+          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer\
+            | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
+        )
+      expected: ../expected/trace-artist-detail.yml
+
+    # event list TODO: Events Implementation needed - no tracking issues yet
+    #    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql event list --service-name=e2e-service-provider --instance-name=provider1
+    #      expected: ../expected/event-list.yml
+
+    # logs list
+    - query: |
+        swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql logs list --service-name=e2e-service-provider --trace-id=$( \
+            swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls \
+              | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
+        )
+      expected: ../expected/logs-list.yml

--- a/tests/e2e/case/http/docker-compose.yml
+++ b/tests/e2e/case/http/docker-compose.yml
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '2.1'
+
+services:
+  oap:
+    extends:
+      file: ../../base/docker-compose.base.yml
+      service: oap
+    ports:
+      - "12800"
+
+  provider:
+    extends:
+      file: ../../base/docker-compose.base.yml
+      service: provider
+    ports:
+      - "9090"
+    environment: # HTTP endpoint
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:12800
+      SW_AGENT_PROTOCOL: http
+    depends_on:
+      oap:
+        condition: service_healthy
+
+  consumer:
+    extends:
+      file: ../../base/docker-compose.base.yml
+      service: consumer
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:12800
+      SW_AGENT_PROTOCOL: http
+    ports:
+      - "9090"
+    depends_on:
+      provider:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/tests/e2e/case/http/e2e.yaml
+++ b/tests/e2e/case/http/e2e.yaml
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: install yq
+      command: bash tests/e2e/script/prepare/install.sh yq
+    - name: install swctl
+      command: bash tests/e2e/script/prepare/install.sh swctl
+
+cleanup:
+  # change to success if debugging.
+  on: never # always for CI
+
+trigger:
+  action: http      # The action of the trigger. support HTTP invoke.
+  interval: 3s      # Trigger the action every 3 seconds.
+  times: 5          # Don't omit this!
+  url: http://${consumer_host}:${consumer_9090}/artist
+  method: POST       # Http trigger method.
+  headers:
+    "Content-Type": "application/json"
+  body: '{"song": "Despacito"}'
+
+verify:
+  # verify with retry strategy
+  retry:
+    # max retry count
+    count: 20
+    # the interval between two retries
+    interval: 5s
+  cases:
+    # basic check: service list
+    # swctl --display yaml --base-url=http://localhost:12800/graphql service ls
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql service ls
+      expected: ../expected/service.yml
+    # basic check: service metrics
+    # swctl --display yaml --base-url=http://localhost:12800/graphql metrics linear --name service_sla --service-name=e2e-service-provider |yq e 'to_entries' -
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name service_sla --service-name=e2e-service-provider |yq e 'to_entries' -
+      expected: ../expected/metrics-has-value.yml
+    # basic check: service endpoint
+    # swctl --display yaml --base-url=http://localhost:12800/graphql endpoint list --keyword=artist --service-name=e2e-service-provider
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql endpoint list --service-name=e2e-service-provider
+      expected: ../expected/service-endpoint.yml
+    # basic check: service endpoint metrics
+    #swctl --display yaml --base-url=http://localhost:12800/graphql metrics linear --name endpoint_cpm --endpoint-name=/artist --service-name=e2e-service-provider |yq e 'to_entries' -
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name endpoint_cpm --endpoint-name=/artist --service-name=e2e-service-provider |yq e 'to_entries' -
+      expected: ../expected/metrics-has-value.yml
+
+    # service instance list
+    # swctl --display yaml --base-url=http://localhost:12800/graphql instance list --service-name=e2e-service-provider
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql instance list --service-name=e2e-service-provider
+      expected: ../expected/service-instance.yml
+
+    # TODO: Metric Collection Implementation is not merged https://github.com/apache/skywalking/issues/7084
+    # service instance pvm metrics TODO: PVM Collection Implementation needed https://github.com/apache/skywalking/issues/5944
+    # swctl --display yaml --base-url=http://localhost:12800/graphql metrics linear --name instance_jvm_thread_live_count --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
+    #    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name instance_jvm_thread_live_count --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
+    #      expected: ../expected/metrics-has-value.yml
+
+    # trace segment list
+    # swctl --display yaml --base-url=http://localhost:12800/graphql trace ls
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls
+      expected: ../expected/traces-list.yml
+    # trace detail
+    - query: |
+        swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace $( \
+          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer\
+            | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
+        )
+      expected: ../expected/trace-artist-detail.yml
+
+    # event list TODO: Events Implementation needed
+    #    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql event list --service-name=e2e-service-provider --instance-name=provider1
+    #      expected: ../expected/event-list.yml
+
+    # logs list
+    - query: |
+        swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql logs list --service-name=e2e-service-provider --trace-id=$( \
+            swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls \
+              | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
+        )
+      expected: ../expected/logs-list.yml

--- a/tests/e2e/case/kafka/docker-compose.yml
+++ b/tests/e2e/case/kafka/docker-compose.yml
@@ -1,0 +1,122 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '2.1'
+
+services:
+  zookeeper:
+    image: zookeeper:3.4
+    hostname: zookeeper
+    expose:
+      - 2181
+    networks:
+      - e2e
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    healthcheck:
+      test: [ "CMD", "sh", "-c", "nc -nz 127.0.0.1 2181" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  broker-a:
+    image: bitnami/kafka:2.4.1
+    hostname: broker-a
+    expose:
+      - 9092
+    networks:
+      - e2e
+    environment:
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_BROKER_ID=10
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "kafka-topics.sh", "--list", "--zookeeper", "zookeeper:2181" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  broker-b:
+    image: bitnami/kafka:2.4.1
+    hostname: broker-b
+    expose:
+      - 9092
+    networks:
+      - e2e
+    environment:
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_BROKER_ID=24
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "kafka-topics.sh", "--list", "--zookeeper", "zookeeper:2181" ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+  oap:
+    extends:
+      file: ../../base/docker-compose.base.yml
+      service: oap
+    environment:
+      SW_KAFKA_FETCHER: default
+      SW_KAFKA_FETCHER_SERVERS: broker-a:9092,broker-b:9092
+      SW_KAFKA_FETCHER_PARTITIONS: 2
+      SW_KAFKA_FETCHER_PARTITIONS_FACTOR: 1
+    depends_on:
+      broker-a:
+        condition: service_healthy
+      broker-b:
+        condition: service_healthy
+    ports:
+      - "12800"
+
+  provider:
+    extends:
+      file: ../../base/docker-compose.base.yml
+      service: provider
+    ports:
+      - "9090"
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
+      SW_AGENT_PROTOCOL: kafka
+      SW_KAFKA_REPORTER_BOOTSTRAP_SERVERS: broker-a:9092,broker-b:9092
+
+    depends_on:
+      oap:
+        condition: service_healthy
+
+  consumer:
+    extends:
+      file: ../../base/docker-compose.base.yml
+      service: consumer
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
+      SW_AGENT_PROTOCOL: kafka
+      SW_KAFKA_REPORTER_BOOTSTRAP_SERVERS: broker-a:9092,broker-b:9092
+    ports:
+      - "9090"
+    depends_on:
+      provider:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/tests/e2e/case/kafka/e2e.yaml
+++ b/tests/e2e/case/kafka/e2e.yaml
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is used to show how to write configuration files and can be used to test.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 20m
+  init-system-environment: ../../script/env
+  steps:
+    - name: install yq
+      command: bash tests/e2e/script/prepare/install.sh yq
+    - name: install swctl
+      command: bash tests/e2e/script/prepare/install.sh swctl
+
+cleanup:
+  # change to success if debugging.
+  on: never # always for CI
+
+trigger:
+  action: http      # The action of the trigger. support HTTP invoke.
+  interval: 3s      # Trigger the action every 3 seconds.
+  times: 5          # Don't omit this!
+  url: http://${consumer_host}:${consumer_9090}/artist
+  method: POST       # Http trigger method.
+  headers:
+    "Content-Type": "application/json"
+  body: '{"song": "Despacito"}'
+
+verify:
+  # verify with retry strategy
+  retry:
+    # max retry count
+    count: 20
+    # the interval between two retries
+    interval: 5s
+  cases:
+    # basic check: service list
+    # swctl --display yaml --base-url=http://localhost:12800/graphql service ls
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql service ls
+      expected: ../expected/service.yml
+    # basic check: service metrics
+    # swctl --display yaml --base-url=http://localhost:12800/graphql metrics linear --name service_sla --service-name=e2e-service-provider |yq e 'to_entries' -
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name service_sla --service-name=e2e-service-provider |yq e 'to_entries' -
+      expected: ../expected/metrics-has-value.yml
+    # basic check: service endpoint
+    # swctl --display yaml --base-url=http://localhost:12800/graphql endpoint list --keyword=artist --service-name=e2e-service-provider
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql endpoint list --service-name=e2e-service-provider
+      expected: ../expected/service-endpoint.yml
+    # basic check: service endpoint metrics
+    #swctl --display yaml --base-url=http://localhost:12800/graphql metrics linear --name endpoint_cpm --endpoint-name=/artist --service-name=e2e-service-provider |yq e 'to_entries' -
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name endpoint_cpm --endpoint-name=/artist --service-name=e2e-service-provider |yq e 'to_entries' -
+      expected: ../expected/metrics-has-value.yml
+
+    # service instance list
+    # swctl --display yaml --base-url=http://localhost:12800/graphql instance list --service-name=e2e-service-provider
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql instance list --service-name=e2e-service-provider
+      expected: ../expected/service-instance.yml
+
+    # TODO: Metric Collection Implementation is not merged https://github.com/apache/skywalking/issues/7084
+    # service instance pvm metrics TODO: PVM Collection Implementation needed https://github.com/apache/skywalking/issues/5944
+    # swctl --display yaml --base-url=http://localhost:12800/graphql metrics linear --name instance_jvm_thread_live_count --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
+    #    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name instance_jvm_thread_live_count --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
+    #      expected: ../expected/metrics-has-value.yml
+
+    # trace segment list
+    # swctl --display yaml --base-url=http://localhost:12800/graphql trace ls
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls
+      expected: ../expected/traces-list.yml
+    # trace detail
+    - query: |
+        swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace $( \
+          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer\
+            | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
+        )
+      expected: ../expected/trace-artist-detail.yml
+
+    # event list TODO: Events Implementation needed
+    #    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql event list --service-name=e2e-service-provider --instance-name=provider1
+    #      expected: ../expected/event-list.yml
+
+    # logs list
+    - query: |
+        swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql logs list --service-name=e2e-service-provider --trace-id=$( \
+            swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls \
+              | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
+        )
+      expected: ../expected/logs-list.yml

--- a/tests/e2e/script/env
+++ b/tests/e2e/script/env
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 2022-03-25 commit
+SW_CTL_COMMIT=60cee4a926a867a7bd934b7f94c9a8517e141608

--- a/tests/e2e/script/prepare/install-swctl.sh
+++ b/tests/e2e/script/prepare/install-swctl.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+BASE_DIR=$1
+BIN_DIR=$2
+
+set -ex
+
+if ! command -v swctl &> /dev/null; then
+  mkdir -p $BASE_DIR/swctl && cd $BASE_DIR/swctl
+  curl -kLo skywalking-cli.tar.gz https://github.com/apache/skywalking-cli/archive/${SW_CTL_COMMIT}.tar.gz
+  tar -zxf skywalking-cli.tar.gz --strip=1
+  utype=$(uname | awk '{print tolower($0)}')
+  make $utype-amd64 && mv bin/swctl-*-$utype-amd64 $BIN_DIR/swctl
+fi

--- a/tests/e2e/script/prepare/install-yq.sh
+++ b/tests/e2e/script/prepare/install-yq.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+BASE_DIR=$1
+BIN_DIR=$2
+
+if ! command -v yq &> /dev/null; then
+  mkdir -p $BASE_DIR/yq && cd $BASE_DIR/yq
+  curl -kLo yq.tar.gz https://github.com/mikefarah/yq/archive/v4.11.1.tar.gz
+  tar -zxf yq.tar.gz --strip=1
+  go install && go build -ldflags -s && cp yq $BIN_DIR/
+fi

--- a/tests/e2e/script/prepare/install.sh
+++ b/tests/e2e/script/prepare/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+set -ex
+
+NAME=$1
+CURRENT_DIR="$(cd "$(dirname $0)"; pwd)"
+
+# prepare base dir
+TMP_DIR=/tmp/skywalking-infra-e2e
+BIN_DIR=/usr/local/bin
+mkdir -p $TMP_DIR && cd $TMP_DIR
+
+# execute install
+bash $CURRENT_DIR/install-$NAME.sh $TMP_DIR $BIN_DIR
+
+echo "success to install $NAME"


### PR DESCRIPTION
- Change Fastapi to FastAPI component name
- Add E2E coverage for Python agent.

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a CHANGELOG entry for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
- [ ] Rebuild the `Plugins.md` documentation by running `tools/doc/plugin_doc_gen.py`
-->
